### PR TITLE
Rework docker image to run as regular user

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,39 +85,17 @@ conda env create -f environment.yml
 conda activate splatam
 ``` -->
 
-#### Windows
-
-For installation on Windows using Git bash, please refer to the [instructions shared in Issue#9](https://github.com/spla-tam/SplaTAM/issues/9#issuecomment-1848348403).
-
-#### Docker and Singularity Setup
+#### Docker Setup
 
 We also provide a docker image. We recommend using a venv to run the code inside a docker image:
 
 
 ```bash
-docker pull nkeetha/splatam:v1
-bash bash_scripts/start_docker.bash
-cd /SplaTAM/
-pip install virtualenv --user
-mkdir venv
-cd venv
-virtualenv --system-site-packages splatam
-source ./splatam/bin/activate
-pip install -r venv_requirements.txt
-```
-
-Setting up a singularity container is similar:
-```bash
-cd </path/to/singularity/folder/>
-singularity pull splatam.sif docker://nkeetha/splatam:v1
-singularity instance start --nv splatam.sif splatam
-singularity run --nv instance://splatam
-cd <path/to/SplaTAM/>
-pip install virtualenv --user
-mkdir venv
-cd venv
-virtualenv --system-site-packages splatam
-source ./splatam/bin/activate
+bash docker/build.sh
+bash docker/run.sh
+cd /ws/SplaTAM/
+python3.10 -m venv --system-site-packages .splatam
+source ./.splatam/bin/activate
 pip install -r venv_requirements.txt
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,16 +14,9 @@ RUN apt-get update -y \
     && apt-get install software-properties-common -y \
     && add-apt-repository ppa:deadsnakes/ppa -y
 RUN apt-get update -y && apt-get install -y \
-        python3.10 
-RUN apt-get update -y && apt-get install -y \
-        python3.10-dev 
-RUN apt-get update -y && apt-get install -y \
-        python3.10-venv 
-RUN apt-get update -y && apt-get install -y \
-        git
-RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
+    python3.10 python3.10-dev python3.10-venv \
+    git ffmpeg libsm6 libxext6 pip
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 RUN ldconfig
 
 # Create user

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+#FROM nkeetha/splatam:v1
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set default user and group arguments that can be overwritten with input args
+ARG UNAME=testuser
+ARG UID=1000
+ARG GID=1000
+
+RUN mkdir -p /ws
+WORKDIR /ws
+
+RUN apt-get update -y \
+    && apt-get install software-properties-common -y \
+    && add-apt-repository ppa:deadsnakes/ppa -y
+RUN apt-get update -y && apt-get install -y \
+        python3.10 
+RUN apt-get update -y && apt-get install -y \
+        python3.10-dev 
+RUN apt-get update -y && apt-get install -y \
+        python3.10-venv 
+RUN apt-get update -y && apt-get install -y \
+        git
+RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
+
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+RUN ldconfig
+
+# Create user
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+USER $UNAME
+
+CMD ["/bin/bash"]
+

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo $(whoami)
-
 docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
     --build-arg UNAME=$(whoami) -t splatam-env ./docker/
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo $(whoami)
+
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+    --build-arg UNAME=$(whoami) -t splatam-env ./docker/
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+timestamp=$(date +%s)
+
+docker run -it \
+    --volume ./:/ws/SplaTAM/ \
+    --volume /tmp/.X11-unix:/tmp/.X11-unix \
+    --rm \
+    --env NVIDIA_VISIBLE_DEVICES=all \
+    --env NVIDIA_DRIVER_CAPABILITIES=all \
+    --env DISPLAY=$DISPLAY \
+    --net=host \
+    --privileged \
+    --group-add audio \
+    --group-add video \
+    --ulimit memlock=-1 \
+    --ulimit stack=67108864 \
+    --name splatam-$timestamp \
+    --ipc=host \
+    --gpus all \
+    splatam-env \
+    /bin/bash
+    


### PR DESCRIPTION
Adding:
* `Dockerfile` with Python3.10 support and creating regular user.
* `build.sh` and `run.sh` to build and run the container.
Modifying:
* `README.md` with updated instructions to use the Docker container.