### PR TITLE
Modify depth dimensions to match our input

### DIFF
--- a/scripts/splatam.py
+++ b/scripts/splatam.py
@@ -107,9 +107,9 @@ def get_pointcloud(color, depth, intrinsics, w2c, transform_pts=True,
 
     # Select points based on mask
     if mask is not None:
-        point_cld = point_cld[mask]
+        #point_cld = point_cld[mask]
         if compute_mean_sq_dist:
-            mean3_sq_dist = mean3_sq_dist[mask]
+            mean3_sq_dist = mean3_sq_dist[mask[::3]]
 
     if compute_mean_sq_dist:
         return point_cld, mean3_sq_dist
@@ -173,6 +173,8 @@ def initialize_first_timestep(dataset, num_frames, scene_radius_depth_ratio,
 
     # Process RGB-D Data
     color = color.permute(2, 0, 1) / 255 # (H, W, C) -> (C, H, W)
+    # Flatten to match expected dimensions
+    depth = torch.flatten(depth, start_dim=2)
     depth = depth.permute(2, 0, 1) # (H, W, C) -> (C, H, W)
     
     # Process Camera Parameters
@@ -186,6 +188,8 @@ def initialize_first_timestep(dataset, num_frames, scene_radius_depth_ratio,
         # Get Densification RGB-D Data & Camera Parameters
         color, depth, densify_intrinsics, _ = densify_dataset[0]
         color = color.permute(2, 0, 1) / 255 # (H, W, C) -> (C, H, W)
+        # Flatten to match expected dimensions
+        depth = torch.flatten(depth, start_dim=2)
         depth = depth.permute(2, 0, 1) # (H, W, C) -> (C, H, W)
         densify_intrinsics = densify_intrinsics[:3, :3]
         densify_cam = setup_camera(color.shape[2], color.shape[1], densify_intrinsics.cpu().numpy(), w2c.detach().cpu().numpy())
@@ -281,7 +285,7 @@ def get_loss(params, curr_data, variables, iter_time_idx, loss_weights, use_sil_
     
     # RGB Loss
     if tracking and (use_sil_for_loss or ignore_outlier_depth_loss):
-        color_mask = torch.tile(mask, (3, 1, 1))
+        color_mask = torch.tile(mask, (1, 1, 1))
         color_mask = color_mask.detach()
         losses['im'] = torch.abs(curr_data['im'] - im)[color_mask].sum()
     elif tracking:
@@ -404,6 +408,7 @@ def add_new_gaussians(params, variables, curr_data, sil_thres,
         curr_w2c[:3, 3] = curr_cam_tran
         valid_depth_mask = (curr_data['depth'][0, :, :] > 0)
         non_presence_mask = non_presence_mask & valid_depth_mask.reshape(-1)
+        non_presence_mask = torch.tile(non_presence_mask, (3,))
         new_pt_cld, mean3_sq_dist = get_pointcloud(curr_data['im'], curr_data['depth'], curr_data['intrinsics'], 
                                     curr_w2c, mask=non_presence_mask, compute_mean_sq_dist=True,
                                     mean_sq_dist_method=mean_sq_dist_method)
@@ -632,6 +637,8 @@ def rgbd_slam(config: dict):
                 curr_w2c[:3, 3] = curr_cam_tran
                 # Initialize Keyframe Info
                 color = color.permute(2, 0, 1) / 255
+                # Flatten to match expected dimensions
+                depth = torch.flatten(depth, start_dim=2)
                 depth = depth.permute(2, 0, 1)
                 curr_keyframe = {'id': time_idx, 'est_w2c': curr_w2c, 'color': color, 'depth': depth}
                 # Add to keyframe list
@@ -647,6 +654,8 @@ def rgbd_slam(config: dict):
         gt_w2c = torch.linalg.inv(gt_pose)
         # Process RGB-D Data
         color = color.permute(2, 0, 1) / 255
+        # Flatten to match expected dimensions
+        depth = torch.flatten(depth, start_dim=2)
         depth = depth.permute(2, 0, 1)
         gt_w2c_all_frames.append(gt_w2c)
         curr_gt_w2c = gt_w2c_all_frames
@@ -782,6 +791,7 @@ def rgbd_slam(config: dict):
                     # Load RGBD frames incrementally instead of all frames
                     densify_color, densify_depth, _, _ = densify_dataset[time_idx]
                     densify_color = densify_color.permute(2, 0, 1) / 255
+                    densify_depth = torch.flatten(densify_depth, start_dim=2)
                     densify_depth = densify_depth.permute(2, 0, 1)
                     densify_curr_data = {'cam': densify_cam, 'im': densify_color, 'depth': densify_depth, 'id': time_idx, 
                                  'intrinsics': densify_intrinsics, 'w2c': first_frame_w2c, 'iter_gt_w2c_list': curr_gt_w2c}

--- a/scripts/splatam.py
+++ b/scripts/splatam.py
@@ -107,9 +107,9 @@ def get_pointcloud(color, depth, intrinsics, w2c, transform_pts=True,
 
     # Select points based on mask
     if mask is not None:
-        #point_cld = point_cld[mask]
+        point_cld = point_cld[mask]
         if compute_mean_sq_dist:
-            mean3_sq_dist = mean3_sq_dist[mask[::3]]
+            mean3_sq_dist = mean3_sq_dist[mask]
 
     if compute_mean_sq_dist:
         return point_cld, mean3_sq_dist
@@ -197,7 +197,8 @@ def initialize_first_timestep(dataset, num_frames, scene_radius_depth_ratio,
         densify_intrinsics = intrinsics
 
     # Get Initial Point Cloud (PyTorch CUDA Tensor)
-    mask = (depth > 0) # Mask out invalid depth values
+    depth_z = depth[0] # Take only the 1st channel
+    mask = (depth_z > 0) # Mask out invalid depth values
     mask = mask.reshape(-1)
     init_pt_cld, mean3_sq_dist = get_pointcloud(color, depth, densify_intrinsics, w2c, 
                                                 mask=mask, compute_mean_sq_dist=True, 
@@ -408,7 +409,6 @@ def add_new_gaussians(params, variables, curr_data, sil_thres,
         curr_w2c[:3, 3] = curr_cam_tran
         valid_depth_mask = (curr_data['depth'][0, :, :] > 0)
         non_presence_mask = non_presence_mask & valid_depth_mask.reshape(-1)
-        non_presence_mask = torch.tile(non_presence_mask, (3,))
         new_pt_cld, mean3_sq_dist = get_pointcloud(curr_data['im'], curr_data['depth'], curr_data['intrinsics'], 
                                     curr_w2c, mask=non_presence_mask, compute_mean_sq_dist=True,
                                     mean_sq_dist_method=mean_sq_dist_method)

--- a/utils/eval_helpers.py
+++ b/utils/eval_helpers.py
@@ -132,7 +132,7 @@ def plot_rgbd_silhouette(color, depth, rastered_color, rastered_depth, presence_
         axs[0, 2].imshow(presence_sil_mask, cmap='gray')
         axs[0, 2].set_title("Rasterized Silhouette")
     diff_depth_l1 = diff_depth_l1.cpu().squeeze(0)
-    axs[1, 2].imshow(diff_depth_l1, cmap='jet', vmin=0, vmax=6)
+    axs[1, 2].imshow(diff_depth_l1.permute(1, 2, 0), cmap='jet', vmin=0, vmax=6)
     axs[1, 2].set_title("Diff Depth L1")
     for ax in axs.flatten():
         ax.axis('off')
@@ -435,6 +435,7 @@ def eval(dataset, final_params, num_frames, eval_dir, sil_thres,
 
         # Process RGB-D Data
         color = color.permute(2, 0, 1) / 255 # (H, W, C) -> (C, H, W)
+        depth = depth.flatten(start_dim=2)
         depth = depth.permute(2, 0, 1) # (H, W, C) -> (C, H, W)
 
         if time_idx == 0:

--- a/venv_requirements.txt
+++ b/venv_requirements.txt
@@ -11,4 +11,6 @@ torchmetrics
 cyclonedds
 pytorch-msssim
 plyfile==0.8.1
+opencv-python
+open3d
 git+https://github.com/JonathonLuiten/diff-gaussian-rasterization-w-depth.git@cb65e4b86bc3bd8ed42174b72a62e8d3a3a71110

--- a/viz_scripts/final_recon.py
+++ b/viz_scripts/final_recon.py
@@ -186,6 +186,9 @@ def visualize(scene_path, cfg):
     pcd = o3d.geometry.PointCloud()
     pcd.points = init_pts
     pcd.colors = init_cols
+    path = cfg['output']
+    o3d.io.write_point_cloud(path, pcd);
+    print("PCD written at: ", path);
     vis.add_geometry(pcd)
 
     w = cfg['viz_w']
@@ -279,6 +282,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("experiment", type=str, help="Path to experiment file")
+    parser.add_argument("pointcloud", type=str, help="Path to write output pointcloud file")
 
     args = parser.parse_args()
 
@@ -296,6 +300,7 @@ if __name__ == "__main__":
     else:
         scene_path = experiment.config["scene_path"]
     viz_cfg = experiment.config["viz"]
+    viz_cfg["output"] = args.pointcloud
 
     # Visualize Final Reconstruction
     visualize(scene_path, viz_cfg)


### PR DESCRIPTION
The original application is intended to be executed while capturing the NeRF input at the same time, or transmitting the input with DSS.

This PR performs the required tweaks to use previously recorded datasets in the following format:
```
dataset-dir
|
|--- depth
|    |
|    `--- 0.png
|--- rgb
|    |
|    `--- 0.png
|
` transforms.json
```

## Changes:
* The `depth` vector has the channels separated into 3 vectors, but the algorithm expects them to be all in 1 vector. Flattening the last dimension solves this by taking those 3 vectors and joining them.

* When using the `depth` mask for the `color_mask`, it is expected that it has only 1 channel instead of 3, so the tiling is adapted for 3 channels. This is because the depth image is black and white, and could have been represented with 1 channel.

* Add the possibility of generating a pointcloud output with the visualization script.
**WARNING:** Visualization script freezes if there is no GUI when ran.